### PR TITLE
Put text and images under the CC-BY-3.0 license

### DIFF
--- a/layouts/partials/blog-footer.html
+++ b/layouts/partials/blog-footer.html
@@ -1,41 +1,5 @@
-<!-- Footer -->
-<footer id="footer">
-  <div class="container">
-    <div class="row">
-      <div class="col-md-6 col-md-offset-3 text-center">
-        <a href="https://github.com/LibrePCB/LibrePCB" class="icon-octocat icon-2x"></a>
-        <p><a href="index.xml">RSS Feed</a></p>
-        <p><script>document.write('Copyright &copy; ' ); document.write(new Date().getFullYear());document.write(' Urban Bruhin' );</script></p>
-      </div>
-    </div>
-  </div>
-</footer>
-<!-- /Footer -->
+<div class="counterpoint col-md-8 col-md-offset-2 text-center">
+  <a href="index.xml">RSS Feed</a>
+</div>
 
-<!-- Bootstrap core JavaScript -->
-<!-- Placed at the end of the document so the pages load faster -->
-<script src="/js/jquery-2.1.1.min.js"></script>
-<script src="/js/owl.carousel.min.js"></script>
-<!--<script src="/js/bootstrap.min.js"></script>-->
-<script>
-$(function() {
-$('a[href*=#]:not([href=#])').click(function() {
-  if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'')
-      || location.hostname == this.hostname) {
-
-    var target = $(this.hash);
-    target = target.length ? target : $('[name=' + this.hash.slice(1) +']');
-    if (target.length) {
-      $('html,body').animate({
-        scrollTop: target.offset().top
-      }, 1000);
-      return false;
-    }
-  }
-});
-});
-</script>
-
-</body>
-
-</html>
+{{ partial "footer.html" . }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,9 +2,17 @@
 <footer id="footer">
   <div class="container">
     <div class="row">
-      <div class="col-md-6 col-md-offset-3 text-center">
+      <div class="col-md-8 col-md-offset-2 text-center">
         <a href="https://github.com/LibrePCB/LibrePCB" class="icon-octocat icon-2x"></a>
-        <p><script>document.write('Copyright &copy; ' ); document.write(new Date().getFullYear());document.write(' Urban Bruhin' );</script></p>
+        <p><em><small>
+          Unless otherwise stated, text and images on this site are licensed
+          under the
+          <a href="https://creativecommons.org/licenses/by/3.0/">
+            Creative Commons Attribution License 3.0
+          </a> or later. This does not include any source code, libraries,
+          documentation, and third party tools or products mentioned on this
+          site.
+        </small></em></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
See discussion in #42.

[Preview](https://librepcb.org/_branches/website-license-cc-by/):

![image](https://user-images.githubusercontent.com/5374821/147423172-cb10baff-dec1-4269-b8d1-0690114526f3.png)

The license text in the footer is inspired by:

[creativecommons.org](https://creativecommons.org):

![image](https://user-images.githubusercontent.com/5374821/147423125-75e1925b-42c8-420d-81ac-de9c0293470b.png)

[kicad.org](https://www.kicad.org):

![image](https://user-images.githubusercontent.com/5374821/147423138-22397ef2-2775-4820-aa87-4d568afb41bd.png)

@dbrgn For legal correctness since you are the only contributor of this repository beside myself: Do you agree to put the content you have contributed under this license? :slightly_smiling_face: 