### PR TITLE
fix grammar: "let's" → "lets"

### DIFF
--- a/content/features/schematic-editor/index.adoc
+++ b/content/features/schematic-editor/index.adoc
@@ -16,7 +16,7 @@ The schematic editor provides the following features:
 
 == icon:search[] Fast, Global Part Search
 
-The part search function let's you find parts in all installed libraries very
+The part search function lets you find parts in all installed libraries very
 quickly:
 
 [.rounded-window.window-border]

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -25,7 +25,7 @@
               beginners to experts.
             </p>
             <p>
-              This software just let&rsquo;s you develop electronics the right
+              This software just lets you develop electronics the right
               way.
               <br class="d-none d-md-inline-block">
               No costs. No restrictions. No online account.


### PR DESCRIPTION
Replace "let's" with "lets" where it stands for "let" in third person singular, not for "let us".