### PR TITLE
Download page: Show known issue for Italian users

### DIFF
--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -74,7 +74,17 @@ function registerDownloadDialog() {
   }
 }
 
+function showKnownIssueIfItalian() {
+  if (navigator.languages.includes("it") || navigator.languages.includes("it-CH")) {
+    var divs = document.getElementsByClassName("known-issue-italian-0.1.7");
+    for (var div of divs) {
+      div.classList.remove("d-none");
+    }
+  }
+}
+
 uncloakMail();
 reorderDownloadSections();
 disableOtherDownloadButtons();
 registerDownloadDialog();
+showKnownIssueIfItalian();

--- a/content/download/index.adoc
+++ b/content/download/index.adoc
@@ -28,6 +28,16 @@ For help & more information, check out the
 https://librepcb.org/docs/installation/[*installation instructions*].
 ====
 
+// Important known issue for LibrePCB 0.1.7. Should be removed after the next
+// release (including the JS function showKnownIssueIfItalian()).
+[IMPORTANT.known-issue-italian-{version}.d-none]
+====
+**For Italian Users**:
+LibrePCB 0.1.7 unfortunately contains a bug which could cause a crash if the
+language is set to Italian. For the available workarounds, check out
+https://github.com/LibrePCB/LibrePCB/issues/1101#issuecomment-1429794854[this comment].
+====
+
 [.download-section.windows]
 == {{< icon "fa-brands fa-windows" >}} Windows
 


### PR DESCRIPTION
If the browser language is set to Italian, show a warning on the download page to inform about the bug with Italian translation. Not shown if the browser isn't set to Italian to avoid disrupting users from the rest of the world. Implemented with JS (warning hidden if JS is disabled).

See https://github.com/LibrePCB/LibrePCB/issues/1101#issuecomment-1429794854