### PR TITLE
Add Mastodon link to header

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -99,6 +99,10 @@
     color: rgb(29, 155, 240);
 }
 
+.navbar .icon-mastodon {
+    color: rgb(192, 187, 223);
+}
+
 /* Side navigation */
 
 .nav-container .list-group-item.list-group-item-action.active {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -110,17 +110,24 @@
                 </a>
               </li>
               <li class="nav-item">
-                <a href="https://www.patreon.com/librepcb" title="Patreon"
-                   class="nav-link icon icon-patreon">
-                  <i class="fa-brands fa-patreon fa-xl"></i>
-                  <span class="d-lg-none ms-1">Patreon</span>
+                <a rel="me" href="https://fosstodon.org/@librepcb"
+                   title="Mastodon" class="nav-link icon icon-mastodon">
+                  <i class="fa-brands fa-mastodon fa-xl"></i>
+                  <span class="d-lg-none ms-1">Mastodon</span>
                 </a>
               </li>
               <li class="nav-item">
                 <a href="https://twitter.com/librepcb" title="Twitter"
-                    class="nav-link icon icon-twitter">
+                   class="nav-link icon icon-twitter">
                   <i class="fa-brands fa-twitter fa-xl"></i>
                   <span class="d-lg-none ms-1">Twitter</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a href="https://www.patreon.com/librepcb" title="Patreon"
+                   class="nav-link icon icon-patreon">
+                  <i class="fa-brands fa-patreon fa-xl"></i>
+                  <span class="d-lg-none ms-1">Patreon</span>
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
Using a very light blue since the original Mastodon blue is too dark for the header.

Moved the Patreon link to the right for optical reasons due to the colors.

Preview:  https://librepcb.org/_branches/add-mastodon-link/