### PR TITLE
Add walkthrough video to home page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -251,6 +251,10 @@ div.intro-screenshot-odd {
     background: rgb(88, 88, 88);
 }
 
+.intro-video {
+    max-width: 952px;
+}
+
 .intro-sponsors {
     padding: 20px 0 40px 0;
     background: rgb(88, 88, 88);

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -94,6 +94,16 @@
     </div>
   </div>
 
+  <div class="intro-screenshot intro-screenshot-odd container-fluid text-center">
+    <div class="container d-flex align-items-center justify-content-center py-3">
+      <div class="container-fluid intro-video shadow-lg p-0 m-0">
+        <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+          <iframe src="https://www.youtube-nocookie.com/embed/Nx0bYLi30O0" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen title="YouTube Video"></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="intro-screenshot container-fluid text-center">
     <div class="container">
       <h1>Schematic Editor</h1>


### PR DESCRIPTION
I think this video should be right on our home page since many users expect some quick introduction video when looking for an EDA tool...

Preview: https://librepcb.org/_branches/add-walkthrough-video/

Not sure if a title should be added to the new section or not :thinking: 