### PR TITLE
Fix minimum macOS requirement on download page

### DIFF
--- a/content/download/index.adoc
+++ b/content/download/index.adoc
@@ -58,9 +58,10 @@ _Requirements: Windows 7 or later._
 ++++
 
 [.download-section.macos]
-== {{< icon "fa-brands fa-apple" >}} MacOS
+== {{< icon "fa-brands fa-apple" >}} macOS
 
-_Requirements: MacOS 10.14 or later (64-bit)._
+_Requirements: macOS 11 or later (macOS 10.14 when
+https://librepcb.org/docs/installation/build-from-sources/[building from sources])_
 
 [subs="attributes"]
 ++++


### PR DESCRIPTION
Bump minimum macOS version to 11 and mention building from sources for older versions. See https://librepcb.discourse.group/t/crash-with-sigsegv-on-mac-os-10-14-6/623.

Removed the `(64-bit)` because [according Wikipedia](https://en.wikipedia.org/wiki/MacOS_version_history) 32-bit CPUs are not supported anymore for quite some time.