### PR TITLE
Add links to user feedback survey

### DIFF
--- a/content/contribute/index.adoc
+++ b/content/contribute/index.adoc
@@ -28,8 +28,11 @@ https://github.com/LibrePCB/librepcb-doc/blob/master/CONTRIBUTING.md[`CONTRIBUTI
 
 == icon:message[] Feedback
 
-Your point of view as a LibrePCB user is very valuable for the developers.
-Did you find a bug? Is something unclear with the user interface or the
+Your point of view as a (potential) LibrePCB user is very valuable for the
+developers. Please share your opinion about LibrePCB with us by attending
+to the https://show.forms.app/librepcb/feedback[user feedback survey].
+
+Or did you find a bug? Is something unclear with the user interface or the
 documentation? Do you have an improvement idea? Either
 https://github.com/LibrePCB/LibrePCB/issues[open an issue] or
 https://librepcb.discourse.group/[start a discussion thread] to let us know!

--- a/content/download/index.adoc
+++ b/content/download/index.adoc
@@ -175,9 +175,10 @@ All current and previous releases are available at {releases-url}.
           for further information.
         </p>
         <div class="alert alert-info">
-          <b>Please consider making a donation</b> to support the
-          development of LibrePCB. This will help us a lot to make
-          LibrePCB even better. Thanks!
+          <b>Please consider
+          <a href="{{< relref "donate/index.adoc" >}}">making a donation</a> and
+          <a href="https://show.forms.app/librepcb/feedback">sharing your feedback</a>
+          with us.</b> This will help us a lot to make LibrePCB even better. Thanks!
         </div>
       </div>
       <div class="modal-footer">

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -7,6 +7,10 @@
       {{ .Date.Local | time.Format ":date_long" }}: <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     </div>
 {{ end }}
+    <div class="position-absolute end-0 m-3 d-none d-lg-block">
+      <i class="fa-solid fa-poll align-middle"></i>
+      <a class="link-light small align-middle" href="https://show.forms.app/librepcb/feedback">User feedback survey</a>
+    </div>
     <div class="d-flex flex-column justify-content-evenly text-center flex-fill">
       <div class="intro-header d-flex justify-content-center align-items-center my-2">
         <img class="intro-logo" src="./img/librepcb.png" alt=""/>


### PR DESCRIPTION
- At the top right corner of the home page (only shown on large screens)
- In the popup after downloading LibrePCB
- In the "Feedback" section of the "Contribute" page

Preview: https://librepcb.org/_branches/link-to-feedback-survey/