### PR TITLE
Replace header link to X by Matrix

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -87,16 +87,16 @@
     color: #dfdfdf;
 }
 
+.navbar .icon:hover {
+    color: #ffffff;
+}
+
 .navbar .icon-youtube:hover {
     color: #ff0000;
 }
 
 .navbar .icon-patreon:hover {
     color: #ff404c;
-}
-
-.navbar .icon-twitter:hover {
-    color: white;
 }
 
 .navbar .icon-mastodon:hover {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -25,7 +25,7 @@
           "name": "LibrePCB",
           "url": "https://librepcb.org",
           "sameAs": [
-            "https://twitter.com/librepcb",
+            "https://fosstodon.org/@librepcb",
             "https://github.com/LibrePCB",
             "https://www.patreon.com/librepcb"
           ]
@@ -124,10 +124,10 @@
                 </a>
               </li>
               <li class="nav-item">
-                <a href="https://twitter.com/librepcb" title="X"
-                   class="nav-link icon icon-twitter">
-                  <i class="fa-brands fa-x-twitter fa-xl"></i>
-                  <span class="d-lg-none ms-1">Twitter</span>
+                <a href="https://matrix.to/#/#librepcb:matrix.org" title="Matrix"
+                   class="nav-link icon icon-matrix">
+                  <i class="fa-solid fa-comments fa-xl"></i>
+                  <span class="d-lg-none ms-1">Matrix</span>
                 </a>
               </li>
               <li class="nav-item">


### PR DESCRIPTION
Removing the link to X to make clear it's not our primary social media account.