### PR TITLE
Improve OpenGraph data, depending on site

### DIFF
--- a/content/blog/2025-03-24_release_1.3.0/index.adoc
+++ b/content/blog/2025-03-24_release_1.3.0/index.adoc
@@ -2,6 +2,7 @@
 date: 2025-03-24
 title: LibrePCB 1.3.0 Released
 author: U. Bruhin
+preview: interactive-html-bom.gif
 ---
 
 Today we released LibrePCB 1.3.0 with an interactive HTML BOM export,

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -5,16 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ .Title }}{{ .Param "titleSuffix" }}</title>
     <meta name=description content="{{ .Param "siteDescription" | safeHTMLAttr }}">
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="https://librepcb.org/img/open-graph-banner.jpg" />
-    <meta name="twitter:title" content="LibrePCB" />
-    <meta name="twitter:description" content="{{ .Param "siteDescription" | safeHTMLAttr }}" />
-    <meta property="twitter:domain" content="librepcb.org">
-    <meta property="og:title" content="LibrePCB" />
-    <meta property="og:description" content="{{ .Param "siteDescription" | safeHTMLAttr }}" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://librepcb.org/" />
-    <meta property="og:image" content="https://librepcb.org/img/open-graph-banner.jpg" />
+{{ partial "opengraph.html" . }}
     <meta itemprop="name" content="LibrePCB">
     <meta itemprop="description" content="{{ .Param "siteDescription" | safeHTMLAttr }}">
     <script type="application/ld+json">

--- a/layouts/partials/opengraph.html
+++ b/layouts/partials/opengraph.html
@@ -1,0 +1,18 @@
+{{- $image := "img/open-graph-banner.jpg" -}}
+{{- with $.Page.Param "preview" -}}
+{{- with $.Page.Resources.Get . -}}
+{{ $image = .RelPermalink }}
+{{- else -}}
+{{ errorf "The preview image of the page is invalid." }}
+{{- end -}}
+{{- end -}}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{ .Title }}{{ .Param "titleSuffix" }}" />
+<meta name="twitter:description" content="{{ with .Description }}{{ . | safeHTMLAttr }}{{ else }}{{ if eq .Section "blog" }}{{ .Summary | safeHTMLAttr }}{{ else }}{{ .Param "siteDescription" | safeHTMLAttr }}{{ end }}{{ end }}" />
+<meta name="twitter:image" content="{{ $image | absURL }}" />
+<meta property="twitter:domain" content="librepcb.org">
+<meta property="og:title" content="{{ .Title }}{{ .Param "titleSuffix" }}" />
+<meta property="og:description" content="{{ with .Description }}{{ . | safeHTMLAttr }}{{ else }}{{ if eq .Section "blog" }}{{ .Summary | safeHTMLAttr }}{{ else }}{{ .Param "siteDescription" | safeHTMLAttr }}{{ end }}{{ end }}" />
+<meta property="og:type" content="{{ if eq .Section "blog" }}article{{ else }}website{{ end }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:image" content="{{ $image | absURL }}"/>


### PR DESCRIPTION
- Make og:title depending on the opened site
- In blog posts, set og:type to article
- In blog posts, use summary as oc:description
- In blog posts, allow to set oc:image